### PR TITLE
3.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 Cas Brugman
+Copyright (c) 2019-2021 Cas Brugman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Godot VoIP 🎤📡
 ![logo](https://raw.githubusercontent.com/casbrugman/godot-voip/master/icon.png "Logo")
 
-Godot-voip is a Godot addon which makes it very easy to setup a voip system in your Godot game. This addon also includes a demo project.
+Godot-voip is a Godot addon which makes it very easy to setup a real time voice chat system in your Godot game. This addon also includes a demo project.
 
 ## Compatibility
 * 2.0: Godot 3.2.x
@@ -24,7 +24,3 @@ Godot-voip is a Godot addon which makes it very easy to setup a voip system in y
 ### Running demo
 1. Go to the [Godot Asset Library](https://godotengine.org/asset-library/asset/425) to download the latest release, or you can clone/download this repository to get the latest commit.
 2. Open downloaded project.
-
-## Issues
-
-In this current implementation there are issues with latency and interruptions. This is because the native way access to the microphone audio is handled. Sadly it is up to engine development to improve this.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 [⮩View in Godot Asset Library](https://godotengine.org/asset-library/asset/425)
->previously godot-voip-demo
 # Godot VoIP 🎤📡
 ![logo](https://raw.githubusercontent.com/casbrugman/godot-voip/master/icon.png "Logo")
 
-Godot-voip is a Godot addon (currently only 3.2) which makes it very easy to setup a voip system in your Godot game. This addon also includes a demo project.
+Godot-voip is a Godot addon which makes it very easy to setup a voip system in your Godot game. This addon also includes a demo project.
+
+## Compatibility
+* 2.0: Godot 3.2.x
+* 3.0: Godot >=3.2.4
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Godot-voip is a Godot addon which makes it very easy to setup a real time voice chat system in your Godot game. This addon also includes a demo project.
 
 ## Compatibility
-* 2.0: Godot 3.2.x
-* 3.0: Godot >=3.2.4
+* 2.0: Godot 3.2
+* 3.0: from Godot 3.2.4
 
 ## Setup
 

--- a/addons/godot-voip/demo/Demo.tscn
+++ b/addons/godot-voip/demo/Demo.tscn
@@ -6,9 +6,21 @@
 [sub_resource type="GDScript" id=1]
 script/source = "extends Control
 
+onready var buttonServer: Button = $MarginContainer/HBoxContainer/VBoxContainer/Server
+onready var buttonClient: Button = $MarginContainer/HBoxContainer/VBoxContainer/Client
+onready var buttonVoice : Button = $MarginContainer/HBoxContainer/VBoxContainer/Voice
+
+onready var checkboxListen: CheckBox = $MarginContainer/HBoxContainer/VBoxContainer/Listen
+
+onready var labelStatus: Label = $MarginContainer/HBoxContainer/VBoxContainer2/Status
+onready var labelLog: Label = $MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer/Log
+
+onready var voip: VoipInstance = $VoipInstance
+onready var network: Network = $Network
+
 func _ready():
-	$VoipInstance.connect(\"received_voice_data\", self, \"_received_voice_data\")
-	$VoipInstance.connect(\"send_voice_data\", self, \"_send_voice_data\")
+	voip.connect(\"received_voice_data\", self, \"_received_voice_data\")
+	voip.connect(\"send_voice_data\", self, \"_send_voice_data\")
 
 	get_tree().connect(\"connected_to_server\", self, \"_connected_ok\")
 	get_tree().connect(\"server_disconnected\", self, \"_server_disconnected\")
@@ -18,52 +30,64 @@ func _ready():
 	get_tree().connect(\"network_peer_disconnected\", self, \"_player_disconnected\")
 
 func _on_Button_server_pressed() -> void:
-	var err = $Network.start_server()
+	var err = network.start_server()
 	if err != OK:
-		$Status.text = \"Failed to create server!\"
+		labelStatus.text = \"Failed to create server!\"
 
-	$Status.text = \"server started\"
-	$Button_server.disabled = true
-	$Button_client.disabled = true
-	$Button_voice.disabled = false
+	labelStatus.text = \"server started\"
+	buttonServer.disabled = true
+	buttonClient.disabled = true
+	buttonVoice.disabled = false
+	checkboxListen.disabled = false
 
 func _on_Button_client_pressed() -> void:
-	var err = $Network.start_client()
+	var err = network.start_client()
 	if err != OK:
-		$Status.text = \"failed to create client!\"
+		labelStatus.text = \"failed to create client!\"
 
-	$Status.text = \"Connecting...\"
-	$Button_server.disabled = true
-	$Button_client.disabled = true
-	$Button_voice.disabled = false
+	labelStatus.text = \"Connecting...\"
 
 func _on_Button_voice_button_down() -> void:
-	$VoipInstance.recording = true
+	voip.recording = true
 
 func _on_Button_voice_button_up() -> void:
-	$VoipInstance.recording = false
+	voip.recording = false
+
+func _on_Listen_toggled(button_pressed: bool) -> void:
+	voip.listen = button_pressed
 
 func _connected_ok():
-	$Status.text = \"Connected ok\"
+	labelStatus.text = \"Connected ok\"
+
+	buttonServer.disabled = true
+	buttonClient.disabled = true
+	buttonVoice.disabled = false
+	checkboxListen.disabled = false
 
 func _connected_fail():
-	$Status.text = \"Failed to connect to server!\"
+	labelStatus.text = \"Failed to connect to server!\"
 
 func _server_disconnected():
-	$Status.text = \"Server disconnected\"
+	labelStatus.text = \"Server disconnected\"
 
+	buttonServer.disabled = false
+	buttonClient.disabled = false
+	buttonVoice.disabled = true
+	checkboxListen.disabled = true
+	buttonVoice.pressed = false
 
 func _player_connected(_id):
-	$ScrollContainer/Log.text += \"Player with id: %s connected\\n\" % _id
+	labelLog.text += \"Player with id: %s connected\\n\" % _id
 
 func _player_disconnected(_id):
-	$ScrollContainer/Log.text += \"Player with id: %s disconnected\\n\" % _id
+	labelLog.text += \"Player with id: %s disconnected\\n\" % _id
 
 func _received_voice_data(data: PoolByteArray, id: int):
-	$ScrollContainer/Log.text += \"received voice data of size:%s from id:%s\\n\" % [data.size(), id]
+	labelLog.text += \"received voice data of size:%s from id:%s\\n\" % [data.size(), id]
 
 func _send_voice_data(data: PoolByteArray):
-	$ScrollContainer/Log.text += \"send voice data of size:%s\\n\" % data.size()
+	labelLog.text += \"send voice data of size:%s\\n\" % data.size()
+
 "
 
 [sub_resource type="GDScript" id=2]
@@ -84,68 +108,114 @@ __meta__ = {
 [node name="Network" type="Node" parent="."]
 script = ExtResource( 2 )
 
-[node name="Button_server" type="Button" parent="."]
-margin_left = 46.3451
-margin_top = 44.2765
-margin_right = 173.345
-margin_bottom = 64.2765
+[node name="VoipInstance" type="Node" parent="."]
+script = ExtResource( 1 )
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_right = 50
+custom_constants/margin_top = 50
+custom_constants/margin_left = 50
+custom_constants/margin_bottom = 50
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
+margin_left = 50.0
+margin_top = 50.0
+margin_right = 974.0
+margin_bottom = 550.0
+custom_constants/separation = 50
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
+margin_right = 150.0
+margin_bottom = 500.0
+rect_min_size = Vector2( 150, 0 )
+custom_constants/separation = 10
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Server" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_right = 150.0
+margin_bottom = 20.0
 text = "Start server"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Button_client" type="Button" parent="."]
-margin_left = 46.3451
-margin_top = 80.0
-margin_right = 173.345
-margin_bottom = 100.0
+[node name="Client" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 30.0
+margin_right = 150.0
+margin_bottom = 50.0
 text = "Start client"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Button_voice" type="Button" parent="."]
-margin_left = 46.3451
-margin_top = 160.0
-margin_right = 173.345
-margin_bottom = 180.0
+[node name="Voice" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 60.0
+margin_right = 150.0
+margin_bottom = 80.0
 disabled = true
 text = "Speak"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Status" type="Label" parent="."]
-margin_left = 220.0
-margin_top = 44.2765
-margin_right = 370.0
-margin_bottom = 58.2765
+[node name="Listen" type="CheckBox" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 90.0
+margin_right = 150.0
+margin_bottom = 114.0
+disabled = true
+text = "Listen"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
+margin_left = 200.0
+margin_right = 924.0
+margin_bottom = 500.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Status" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer2"]
+margin_right = 724.0
+margin_bottom = 14.0
 text = "Status:"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="ScrollContainer" type="ScrollContainer" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 190.0
-margin_top = 71.0
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/HBoxContainer/VBoxContainer2"]
+margin_top = 18.0
+margin_right = 724.0
+margin_bottom = 500.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = SubResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Log" type="Label" parent="ScrollContainer"]
-margin_bottom = 14.0
+[node name="Log" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer"]
+margin_right = 724.0
+margin_bottom = 482.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="VoipInstance" type="Node" parent="."]
-script = ExtResource( 1 )
-
-[connection signal="pressed" from="Button_server" to="." method="_on_Button_server_pressed"]
-[connection signal="pressed" from="Button_client" to="." method="_on_Button_client_pressed"]
-[connection signal="button_down" from="Button_voice" to="." method="_on_Button_voice_button_down"]
-[connection signal="button_up" from="Button_voice" to="." method="_on_Button_voice_button_up"]
-[connection signal="resized" from="ScrollContainer/Log" to="ScrollContainer" method="_on_Log_resized"]
+[connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Server" to="." method="_on_Button_server_pressed"]
+[connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Client" to="." method="_on_Button_client_pressed"]
+[connection signal="button_down" from="MarginContainer/HBoxContainer/VBoxContainer/Voice" to="." method="_on_Button_voice_button_down"]
+[connection signal="button_up" from="MarginContainer/HBoxContainer/VBoxContainer/Voice" to="." method="_on_Button_voice_button_up"]
+[connection signal="toggled" from="MarginContainer/HBoxContainer/VBoxContainer/Listen" to="." method="_on_Listen_toggled"]
+[connection signal="resized" from="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer/Log" to="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer" method="_on_Log_resized"]

--- a/addons/godot-voip/demo/Demo.tscn
+++ b/addons/godot-voip/demo/Demo.tscn
@@ -11,11 +11,11 @@ onready var buttonClient: Button = $MarginContainer/HBoxContainer/VBoxContainer/
 onready var buttonVoice : Button = $MarginContainer/HBoxContainer/VBoxContainer/Voice
 
 onready var checkboxListen: CheckBox = $MarginContainer/HBoxContainer/VBoxContainer/Listen
-onready var sliderInputSensitivity: HSlider = $MarginContainer/HBoxContainer/VBoxContainer/InputSensitivity
+onready var sliderInputThreshold: HSlider = $MarginContainer/HBoxContainer/VBoxContainer/InputThreshold
 
 onready var labelStatus: Label = $MarginContainer/HBoxContainer/VBoxContainer2/Status
 onready var labelLog: Label = $MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer/Log
-onready var spinBoxInputSensitivity: SpinBox = $MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/Value
+onready var spinBoxInputThreshold: SpinBox = $MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/Value
 
 onready var voip: VoipInstance = $VoipInstance
 onready var network: Network = $Network
@@ -31,7 +31,7 @@ func _ready():
 	get_tree().connect(\"network_peer_connected\", self, \"_player_connected\")
 	get_tree().connect(\"network_peer_disconnected\", self, \"_player_disconnected\")
 
-	sliderInputSensitivity.value = voip.input_sensitivity
+	sliderInputThreshold.value = voip.input_threshold
 
 func _on_Button_server_pressed() -> void:
 	var err = network.start_server()
@@ -43,8 +43,8 @@ func _on_Button_server_pressed() -> void:
 	buttonClient.disabled = true
 	buttonVoice.disabled = false
 	checkboxListen.disabled = false
-	sliderInputSensitivity.editable = true
-	spinBoxInputSensitivity.editable = true
+	sliderInputThreshold.editable = true
+	spinBoxInputThreshold.editable = true
 
 func _on_Button_client_pressed() -> void:
 	var err = network.start_client()
@@ -62,12 +62,12 @@ func _on_Button_voice_button_up() -> void:
 func _on_Listen_toggled(button_pressed: bool) -> void:
 	voip.listen = button_pressed
 
-func _on_InputSensitivity_value_changed(value: float) -> void:
-	voip.input_sensitivity = value
-	spinBoxInputSensitivity.value = value
+func _on_InputThreshold_value_changed(value: float) -> void:
+	voip.input_threshold = value
+	spinBoxInputThreshold.value = value
 
 func _on_Value_value_changed(value: float) -> void:
-	sliderInputSensitivity.value = value
+	sliderInputThreshold.value = value
 
 func _connected_ok():
 	labelStatus.text = \"Connected ok\"
@@ -76,8 +76,8 @@ func _connected_ok():
 	buttonClient.disabled = true
 	buttonVoice.disabled = false
 	checkboxListen.disabled = false
-	sliderInputSensitivity.editable = true
-	spinBoxInputSensitivity.editable = true
+	sliderInputThreshold.editable = true
+	spinBoxInputThreshold.editable = true
 
 func _connected_fail():
 	labelStatus.text = \"Failed to connect to server!\"
@@ -90,8 +90,8 @@ func _server_disconnected():
 	buttonVoice.disabled = true
 	checkboxListen.disabled = true
 	buttonVoice.pressed = false
-	sliderInputSensitivity.editable = false
-	spinBoxInputSensitivity.editable = false
+	sliderInputThreshold.editable = false
+	spinBoxInputThreshold.editable = false
 
 func _player_connected(_id):
 	labelLog.text += \"Player with id: %s connected\\n\" % _id
@@ -143,7 +143,7 @@ __meta__ = {
 margin_left = 50.0
 margin_top = 50.0
 margin_right = 974.0
-margin_bottom = 909.0
+margin_bottom = 550.0
 custom_constants/separation = 50
 __meta__ = {
 "_edit_use_anchors_": false
@@ -151,7 +151,7 @@ __meta__ = {
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 margin_right = 250.0
-margin_bottom = 859.0
+margin_bottom = 500.0
 rect_min_size = Vector2( 250, 0 )
 custom_constants/separation = 10
 __meta__ = {
@@ -192,15 +192,15 @@ margin_bottom = 118.0
 
 [node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
 margin_top = 5.0
-margin_right = 108.0
+margin_right = 103.0
 margin_bottom = 19.0
-text = "Input sensitivity:"
+text = "Input threshold:"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Value" type="SpinBox" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
-margin_left = 112.0
+margin_left = 107.0
 margin_right = 250.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
@@ -208,7 +208,7 @@ max_value = 1.0
 step = 0.0
 editable = false
 
-[node name="InputSensitivity" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="InputThreshold" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer"]
 margin_top = 128.0
 margin_right = 250.0
 margin_bottom = 144.0
@@ -232,7 +232,7 @@ __meta__ = {
 [node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 margin_left = 300.0
 margin_right = 924.0
-margin_bottom = 859.0
+margin_bottom = 500.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -247,7 +247,7 @@ __meta__ = {
 [node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/HBoxContainer/VBoxContainer2"]
 margin_top = 18.0
 margin_right = 624.0
-margin_bottom = 859.0
+margin_bottom = 500.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = SubResource( 2 )
@@ -257,7 +257,7 @@ __meta__ = {
 
 [node name="Log" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer"]
 margin_right = 624.0
-margin_bottom = 841.0
+margin_bottom = 482.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 __meta__ = {
@@ -268,7 +268,7 @@ __meta__ = {
 [connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Client" to="." method="_on_Button_client_pressed"]
 [connection signal="toggled" from="MarginContainer/HBoxContainer/VBoxContainer/Listen" to="." method="_on_Listen_toggled"]
 [connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/Value" to="." method="_on_Value_value_changed"]
-[connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/InputSensitivity" to="." method="_on_InputSensitivity_value_changed"]
+[connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/InputThreshold" to="." method="_on_InputThreshold_value_changed"]
 [connection signal="button_down" from="MarginContainer/HBoxContainer/VBoxContainer/Voice" to="." method="_on_Button_voice_button_down"]
 [connection signal="button_up" from="MarginContainer/HBoxContainer/VBoxContainer/Voice" to="." method="_on_Button_voice_button_up"]
 [connection signal="resized" from="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer/Log" to="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer" method="_on_Log_resized"]

--- a/addons/godot-voip/demo/Demo.tscn
+++ b/addons/godot-voip/demo/Demo.tscn
@@ -82,10 +82,10 @@ func _player_connected(_id):
 func _player_disconnected(_id):
 	labelLog.text += \"Player with id: %s disconnected\\n\" % _id
 
-func _received_voice_data(data: PoolByteArray, id: int):
+func _received_voice_data(data: PoolRealArray, id: int):
 	labelLog.text += \"received voice data of size:%s from id:%s\\n\" % [data.size(), id]
 
-func _send_voice_data(data: PoolByteArray):
+func _send_voice_data(data: PoolRealArray):
 	labelLog.text += \"send voice data of size:%s\\n\" % data.size()
 
 "

--- a/addons/godot-voip/demo/Demo.tscn
+++ b/addons/godot-voip/demo/Demo.tscn
@@ -205,7 +205,7 @@ margin_right = 250.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 max_value = 1.0
-step = 0.001
+step = 0.0
 editable = false
 
 [node name="InputSensitivity" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer"]

--- a/addons/godot-voip/demo/Demo.tscn
+++ b/addons/godot-voip/demo/Demo.tscn
@@ -11,9 +11,11 @@ onready var buttonClient: Button = $MarginContainer/HBoxContainer/VBoxContainer/
 onready var buttonVoice : Button = $MarginContainer/HBoxContainer/VBoxContainer/Voice
 
 onready var checkboxListen: CheckBox = $MarginContainer/HBoxContainer/VBoxContainer/Listen
+onready var sliderInputSensitivity: HSlider = $MarginContainer/HBoxContainer/VBoxContainer/InputSensitivity
 
 onready var labelStatus: Label = $MarginContainer/HBoxContainer/VBoxContainer2/Status
 onready var labelLog: Label = $MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer/Log
+onready var labelInputSensitivity: Label = $MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/Value
 
 onready var voip: VoipInstance = $VoipInstance
 onready var network: Network = $Network
@@ -29,6 +31,8 @@ func _ready():
 	get_tree().connect(\"network_peer_connected\", self, \"_player_connected\")
 	get_tree().connect(\"network_peer_disconnected\", self, \"_player_disconnected\")
 
+	sliderInputSensitivity.value = voip.input_sensitivity
+
 func _on_Button_server_pressed() -> void:
 	var err = network.start_server()
 	if err != OK:
@@ -39,6 +43,7 @@ func _on_Button_server_pressed() -> void:
 	buttonClient.disabled = true
 	buttonVoice.disabled = false
 	checkboxListen.disabled = false
+	sliderInputSensitivity.editable = true
 
 func _on_Button_client_pressed() -> void:
 	var err = network.start_client()
@@ -56,6 +61,10 @@ func _on_Button_voice_button_up() -> void:
 func _on_Listen_toggled(button_pressed: bool) -> void:
 	voip.listen = button_pressed
 
+func _on_InputSensitivity_value_changed(value: float) -> void:
+	voip.input_sensitivity = value
+	labelInputSensitivity.text = str(value)
+
 func _connected_ok():
 	labelStatus.text = \"Connected ok\"
 
@@ -63,6 +72,7 @@ func _connected_ok():
 	buttonClient.disabled = true
 	buttonVoice.disabled = false
 	checkboxListen.disabled = false
+	sliderInputSensitivity.editable = true
 
 func _connected_fail():
 	labelStatus.text = \"Failed to connect to server!\"
@@ -87,7 +97,6 @@ func _received_voice_data(data: PoolRealArray, id: int):
 
 func _send_voice_data(data: PoolRealArray):
 	labelLog.text += \"send voice data of size:%s\\n\" % data.size()
-
 "
 
 [sub_resource type="GDScript" id=2]
@@ -126,7 +135,7 @@ __meta__ = {
 margin_left = 50.0
 margin_top = 50.0
 margin_right = 974.0
-margin_bottom = 550.0
+margin_bottom = 909.0
 custom_constants/separation = 50
 __meta__ = {
 "_edit_use_anchors_": false
@@ -134,7 +143,7 @@ __meta__ = {
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 margin_right = 150.0
-margin_bottom = 500.0
+margin_bottom = 859.0
 rect_min_size = Vector2( 150, 0 )
 custom_constants/separation = 10
 __meta__ = {
@@ -158,22 +167,53 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Voice" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="Listen" type="CheckBox" parent="MarginContainer/HBoxContainer/VBoxContainer"]
 margin_top = 60.0
 margin_right = 150.0
-margin_bottom = 80.0
+margin_bottom = 84.0
 disabled = true
-text = "Speak"
+text = "Listen"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Listen" type="CheckBox" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-margin_top = 90.0
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 94.0
 margin_right = 150.0
-margin_bottom = 114.0
+margin_bottom = 108.0
+
+[node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
+margin_right = 108.0
+margin_bottom = 14.0
+text = "Input sensitivity:"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Value" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
+margin_left = 112.0
+margin_right = 112.0
+margin_bottom = 14.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="InputSensitivity" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 118.0
+margin_right = 150.0
+margin_bottom = 134.0
+max_value = 1.0
+step = 0.001
+value = 1.0
+editable = false
+ticks_on_borders = true
+
+[node name="Voice" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 144.0
+margin_right = 150.0
+margin_bottom = 164.0
 disabled = true
-text = "Listen"
+text = "Speak"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -181,7 +221,7 @@ __meta__ = {
 [node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 margin_left = 200.0
 margin_right = 924.0
-margin_bottom = 500.0
+margin_bottom = 859.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -196,7 +236,7 @@ __meta__ = {
 [node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/HBoxContainer/VBoxContainer2"]
 margin_top = 18.0
 margin_right = 724.0
-margin_bottom = 500.0
+margin_bottom = 859.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = SubResource( 2 )
@@ -206,7 +246,7 @@ __meta__ = {
 
 [node name="Log" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer"]
 margin_right = 724.0
-margin_bottom = 482.0
+margin_bottom = 841.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 __meta__ = {
@@ -215,7 +255,8 @@ __meta__ = {
 
 [connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Server" to="." method="_on_Button_server_pressed"]
 [connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Client" to="." method="_on_Button_client_pressed"]
+[connection signal="toggled" from="MarginContainer/HBoxContainer/VBoxContainer/Listen" to="." method="_on_Listen_toggled"]
+[connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/InputSensitivity" to="." method="_on_InputSensitivity_value_changed"]
 [connection signal="button_down" from="MarginContainer/HBoxContainer/VBoxContainer/Voice" to="." method="_on_Button_voice_button_down"]
 [connection signal="button_up" from="MarginContainer/HBoxContainer/VBoxContainer/Voice" to="." method="_on_Button_voice_button_up"]
-[connection signal="toggled" from="MarginContainer/HBoxContainer/VBoxContainer/Listen" to="." method="_on_Listen_toggled"]
 [connection signal="resized" from="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer/Log" to="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer" method="_on_Log_resized"]

--- a/addons/godot-voip/demo/Demo.tscn
+++ b/addons/godot-voip/demo/Demo.tscn
@@ -15,7 +15,7 @@ onready var sliderInputSensitivity: HSlider = $MarginContainer/HBoxContainer/VBo
 
 onready var labelStatus: Label = $MarginContainer/HBoxContainer/VBoxContainer2/Status
 onready var labelLog: Label = $MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer/Log
-onready var labelInputSensitivity: Label = $MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/Value
+onready var spinBoxInputSensitivity: SpinBox = $MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/Value
 
 onready var voip: VoipInstance = $VoipInstance
 onready var network: Network = $Network
@@ -44,6 +44,7 @@ func _on_Button_server_pressed() -> void:
 	buttonVoice.disabled = false
 	checkboxListen.disabled = false
 	sliderInputSensitivity.editable = true
+	spinBoxInputSensitivity.editable = true
 
 func _on_Button_client_pressed() -> void:
 	var err = network.start_client()
@@ -63,7 +64,10 @@ func _on_Listen_toggled(button_pressed: bool) -> void:
 
 func _on_InputSensitivity_value_changed(value: float) -> void:
 	voip.input_sensitivity = value
-	labelInputSensitivity.text = str(value)
+	spinBoxInputSensitivity.value = value
+
+func _on_Value_value_changed(value: float) -> void:
+	sliderInputSensitivity.value = value
 
 func _connected_ok():
 	labelStatus.text = \"Connected ok\"
@@ -73,6 +77,7 @@ func _connected_ok():
 	buttonVoice.disabled = false
 	checkboxListen.disabled = false
 	sliderInputSensitivity.editable = true
+	spinBoxInputSensitivity.editable = true
 
 func _connected_fail():
 	labelStatus.text = \"Failed to connect to server!\"
@@ -85,6 +90,8 @@ func _server_disconnected():
 	buttonVoice.disabled = true
 	checkboxListen.disabled = true
 	buttonVoice.pressed = false
+	sliderInputSensitivity.editable = false
+	spinBoxInputSensitivity.editable = false
 
 func _player_connected(_id):
 	labelLog.text += \"Player with id: %s connected\\n\" % _id
@@ -97,6 +104,7 @@ func _received_voice_data(data: PoolRealArray, id: int):
 
 func _send_voice_data(data: PoolRealArray):
 	labelLog.text += \"send voice data of size:%s\\n\" % data.size()
+
 "
 
 [sub_resource type="GDScript" id=2]
@@ -142,16 +150,16 @@ __meta__ = {
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
-margin_right = 150.0
+margin_right = 250.0
 margin_bottom = 859.0
-rect_min_size = Vector2( 150, 0 )
+rect_min_size = Vector2( 250, 0 )
 custom_constants/separation = 10
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Server" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-margin_right = 150.0
+margin_right = 250.0
 margin_bottom = 20.0
 text = "Start server"
 __meta__ = {
@@ -160,7 +168,7 @@ __meta__ = {
 
 [node name="Client" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
 margin_top = 30.0
-margin_right = 150.0
+margin_right = 250.0
 margin_bottom = 50.0
 text = "Start client"
 __meta__ = {
@@ -169,7 +177,7 @@ __meta__ = {
 
 [node name="Listen" type="CheckBox" parent="MarginContainer/HBoxContainer/VBoxContainer"]
 margin_top = 60.0
-margin_right = 150.0
+margin_right = 250.0
 margin_bottom = 84.0
 disabled = true
 text = "Listen"
@@ -179,39 +187,42 @@ __meta__ = {
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
 margin_top = 94.0
-margin_right = 150.0
-margin_bottom = 108.0
+margin_right = 250.0
+margin_bottom = 118.0
 
 [node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
+margin_top = 5.0
 margin_right = 108.0
-margin_bottom = 14.0
+margin_bottom = 19.0
 text = "Input sensitivity:"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Value" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
+[node name="Value" type="SpinBox" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
 margin_left = 112.0
-margin_right = 112.0
-margin_bottom = 14.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="InputSensitivity" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-margin_top = 118.0
-margin_right = 150.0
-margin_bottom = 134.0
+margin_right = 250.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
 max_value = 1.0
 step = 0.001
-value = 1.0
+editable = false
+
+[node name="InputSensitivity" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 128.0
+margin_right = 250.0
+margin_bottom = 144.0
+max_value = 0.1
+step = 0.0
+allow_greater = true
+allow_lesser = true
 editable = false
 ticks_on_borders = true
 
 [node name="Voice" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-margin_top = 144.0
-margin_right = 150.0
-margin_bottom = 164.0
+margin_top = 154.0
+margin_right = 250.0
+margin_bottom = 174.0
 disabled = true
 text = "Speak"
 __meta__ = {
@@ -219,14 +230,14 @@ __meta__ = {
 }
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
-margin_left = 200.0
+margin_left = 300.0
 margin_right = 924.0
 margin_bottom = 859.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Status" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer2"]
-margin_right = 724.0
+margin_right = 624.0
 margin_bottom = 14.0
 text = "Status:"
 __meta__ = {
@@ -235,7 +246,7 @@ __meta__ = {
 
 [node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/HBoxContainer/VBoxContainer2"]
 margin_top = 18.0
-margin_right = 724.0
+margin_right = 624.0
 margin_bottom = 859.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -245,7 +256,7 @@ __meta__ = {
 }
 
 [node name="Log" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer2/ScrollContainer"]
-margin_right = 724.0
+margin_right = 624.0
 margin_bottom = 841.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -256,6 +267,7 @@ __meta__ = {
 [connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Server" to="." method="_on_Button_server_pressed"]
 [connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Client" to="." method="_on_Button_client_pressed"]
 [connection signal="toggled" from="MarginContainer/HBoxContainer/VBoxContainer/Listen" to="." method="_on_Listen_toggled"]
+[connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/Value" to="." method="_on_Value_value_changed"]
 [connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/InputSensitivity" to="." method="_on_InputSensitivity_value_changed"]
 [connection signal="button_down" from="MarginContainer/HBoxContainer/VBoxContainer/Voice" to="." method="_on_Button_voice_button_down"]
 [connection signal="button_up" from="MarginContainer/HBoxContainer/VBoxContainer/Voice" to="." method="_on_Button_voice_button_up"]

--- a/addons/godot-voip/demo/Demo.tscn
+++ b/addons/godot-voip/demo/Demo.tscn
@@ -10,6 +10,9 @@ onready var buttonServer: Button = $MarginContainer/HBoxContainer/VBoxContainer/
 onready var buttonClient: Button = $MarginContainer/HBoxContainer/VBoxContainer/Client
 onready var buttonVoice : Button = $MarginContainer/HBoxContainer/VBoxContainer/Voice
 
+onready var spinBoxHostPort: SpinBox = $MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/Port
+onready var lineEditClientIp: LineEdit = $MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer1/Ip
+onready var spinBoxClientPort: SpinBox = $MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3/Port
 onready var checkboxListen: CheckBox = $MarginContainer/HBoxContainer/VBoxContainer/Listen
 onready var sliderInputThreshold: HSlider = $MarginContainer/HBoxContainer/VBoxContainer/InputThreshold
 
@@ -31,6 +34,9 @@ func _ready():
 	get_tree().connect(\"network_peer_connected\", self, \"_player_connected\")
 	get_tree().connect(\"network_peer_disconnected\", self, \"_player_disconnected\")
 
+	spinBoxHostPort.value = network.server_port
+	lineEditClientIp.text = network.server_ip
+	spinBoxClientPort.value = network.server_port
 	sliderInputThreshold.value = voip.input_threshold
 
 func _on_Button_server_pressed() -> void:
@@ -45,6 +51,9 @@ func _on_Button_server_pressed() -> void:
 	checkboxListen.disabled = false
 	sliderInputThreshold.editable = true
 	spinBoxInputThreshold.editable = true
+	spinBoxHostPort.editable = false
+	lineEditClientIp.editable = false
+	spinBoxClientPort.editable = false
 
 func _on_Button_client_pressed() -> void:
 	var err = network.start_client()
@@ -69,6 +78,12 @@ func _on_InputThreshold_value_changed(value: float) -> void:
 func _on_Value_value_changed(value: float) -> void:
 	sliderInputThreshold.value = value
 
+func _on_Port_value_changed(value: float) -> void:
+	network.server_port = int(value)
+
+func _on_Ip_text_changed(new_text: String) -> void:
+	network.server_ip = new_text
+
 func _connected_ok():
 	labelStatus.text = \"Connected ok\"
 
@@ -78,6 +93,9 @@ func _connected_ok():
 	checkboxListen.disabled = false
 	sliderInputThreshold.editable = true
 	spinBoxInputThreshold.editable = true
+	spinBoxHostPort.editable = false
+	lineEditClientIp.editable = false
+	spinBoxClientPort.editable = false
 
 func _connected_fail():
 	labelStatus.text = \"Failed to connect to server!\"
@@ -92,6 +110,9 @@ func _server_disconnected():
 	buttonVoice.pressed = false
 	sliderInputThreshold.editable = false
 	spinBoxInputThreshold.editable = false
+	spinBoxHostPort.editable = true
+	lineEditClientIp.editable = true
+	spinBoxClientPort.editable = true
 
 func _player_connected(_id):
 	labelLog.text += \"Player with id: %s connected\\n\" % _id
@@ -166,19 +187,103 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Client" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
 margin_top = 30.0
 margin_right = 250.0
-margin_bottom = 50.0
+margin_bottom = 54.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2"]
+margin_top = 5.0
+margin_right = 64.0
+margin_bottom = 19.0
+text = "Host port:"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Port" type="SpinBox" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2"]
+margin_left = 68.0
+margin_right = 250.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+max_value = 65535.0
+rounded = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 64.0
+margin_right = 250.0
+margin_bottom = 68.0
+
+[node name="Client" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 78.0
+margin_right = 250.0
+margin_bottom = 98.0
 text = "Start client"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Listen" type="CheckBox" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-margin_top = 60.0
+[node name="HBoxContainer1" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 108.0
 margin_right = 250.0
-margin_bottom = 84.0
+margin_bottom = 132.0
+
+[node name="Label2" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer1"]
+margin_top = 5.0
+margin_right = 60.0
+margin_bottom = 19.0
+text = "Server ip:"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Ip" type="LineEdit" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer1"]
+margin_left = 64.0
+margin_right = 250.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+text = "127.0.0.1"
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 142.0
+margin_right = 250.0
+margin_bottom = 166.0
+
+[node name="Label2" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3"]
+margin_top = 5.0
+margin_right = 74.0
+margin_bottom = 19.0
+text = "Server port:"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Port" type="SpinBox" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3"]
+margin_left = 78.0
+margin_right = 250.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+max_value = 65535.0
+rounded = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HSeparator2" type="HSeparator" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 176.0
+margin_right = 250.0
+margin_bottom = 180.0
+
+[node name="Listen" type="CheckBox" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+margin_top = 190.0
+margin_right = 250.0
+margin_bottom = 214.0
 disabled = true
 text = "Listen"
 __meta__ = {
@@ -186,9 +291,9 @@ __meta__ = {
 }
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-margin_top = 94.0
+margin_top = 224.0
 margin_right = 250.0
-margin_bottom = 118.0
+margin_bottom = 248.0
 
 [node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
 margin_top = 5.0
@@ -209,9 +314,9 @@ step = 0.0
 editable = false
 
 [node name="InputThreshold" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-margin_top = 128.0
+margin_top = 258.0
 margin_right = 250.0
-margin_bottom = 144.0
+margin_bottom = 274.0
 max_value = 0.1
 step = 0.0
 allow_greater = true
@@ -220,9 +325,9 @@ editable = false
 ticks_on_borders = true
 
 [node name="Voice" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-margin_top = 154.0
+margin_top = 284.0
 margin_right = 250.0
-margin_bottom = 174.0
+margin_bottom = 304.0
 disabled = true
 text = "Speak"
 __meta__ = {
@@ -265,7 +370,10 @@ __meta__ = {
 }
 
 [connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Server" to="." method="_on_Button_server_pressed"]
+[connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/Port" to="." method="_on_Port_value_changed"]
 [connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/Client" to="." method="_on_Button_client_pressed"]
+[connection signal="text_changed" from="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer1/Ip" to="." method="_on_Ip_text_changed"]
+[connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer3/Port" to="." method="_on_Port_value_changed"]
 [connection signal="toggled" from="MarginContainer/HBoxContainer/VBoxContainer/Listen" to="." method="_on_Listen_toggled"]
 [connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/Value" to="." method="_on_Value_value_changed"]
 [connection signal="value_changed" from="MarginContainer/HBoxContainer/VBoxContainer/InputThreshold" to="." method="_on_InputThreshold_value_changed"]

--- a/addons/godot-voip/demo/Demo.tscn
+++ b/addons/godot-voip/demo/Demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://addons/godot-voip/scripts/voip_instance.gd" type="Script" id=1]
 [ext_resource path="res://addons/godot-voip/demo/Network.gd" type="Script" id=2]
@@ -54,16 +54,23 @@ func _server_disconnected():
 
 
 func _player_connected(_id):
-	$Log.text += \"Player with id: %s connected\\n\" % _id
+	$ScrollContainer/Log.text += \"Player with id: %s connected\\n\" % _id
 
 func _player_disconnected(_id):
-	$Log.text += \"Player with id: %s disconnected\\n\" % _id
+	$ScrollContainer/Log.text += \"Player with id: %s disconnected\\n\" % _id
 
 func _received_voice_data(data: PoolByteArray, id: int):
-	$Log.text += \"received voice data of size:%s from id:%s\\n\" % [data.size(), id]
+	$ScrollContainer/Log.text += \"received voice data of size:%s from id:%s\\n\" % [data.size(), id]
 
 func _send_voice_data(data: PoolByteArray):
-	$Log.text += \"send voice data of size:%s\\n\" % data.size()
+	$ScrollContainer/Log.text += \"send voice data of size:%s\\n\" % data.size()
+"
+
+[sub_resource type="GDScript" id=2]
+script/source = "extends ScrollContainer
+
+func _on_Log_resized() -> void:
+	scroll_vertical = $Log.rect_size.y
 "
 
 [node name="Demo" type="Control"]
@@ -118,18 +125,27 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Log" type="Label" parent="."]
-margin_left = 220.0
-margin_top = 100.0
-margin_right = 980.0
-margin_bottom = 340.0
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 190.0
+margin_top = 71.0
+script = SubResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Log" type="Label" parent="ScrollContainer"]
+margin_bottom = 14.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="VoipInstance" type="Node" parent="."]
 script = ExtResource( 1 )
+
 [connection signal="pressed" from="Button_server" to="." method="_on_Button_server_pressed"]
 [connection signal="pressed" from="Button_client" to="." method="_on_Button_client_pressed"]
 [connection signal="button_down" from="Button_voice" to="." method="_on_Button_voice_button_down"]
 [connection signal="button_up" from="Button_voice" to="." method="_on_Button_voice_button_up"]
+[connection signal="resized" from="ScrollContainer/Log" to="ScrollContainer" method="_on_Log_resized"]

--- a/addons/godot-voip/demo/Network.gd
+++ b/addons/godot-voip/demo/Network.gd
@@ -1,4 +1,5 @@
 extends Node
+class_name Network
 
 const SERVER_PORT = 3000
 const MAX_PLAYERS = 20

--- a/addons/godot-voip/demo/Network.gd
+++ b/addons/godot-voip/demo/Network.gd
@@ -1,14 +1,15 @@
 extends Node
 class_name Network
 
-const SERVER_PORT = 3000
-const MAX_PLAYERS = 20
-const SERVER_IP = "127.0.0.1"
+var server_port := 3000
+var server_ip := "127.0.0.1"
+
+const MAX_PLAYERS := 20
 
 func start_client() -> int:
 	var peer = NetworkedMultiplayerENet.new()
 
-	var err = peer.create_client(SERVER_IP, SERVER_PORT)
+	var err = peer.create_client(server_ip, server_port)
 	if err != OK:
 		return err
 
@@ -19,7 +20,7 @@ func start_client() -> int:
 func start_server() -> int:
 	var peer = NetworkedMultiplayerENet.new()
 
-	var err = peer.create_server(SERVER_PORT, MAX_PLAYERS)
+	var err = peer.create_server(server_port, MAX_PLAYERS)
 
 	if err != OK:
 		return err

--- a/addons/godot-voip/plugin.cfg
+++ b/addons/godot-voip/plugin.cfg
@@ -3,5 +3,5 @@
 name="godot-voip"
 description="godot-voip"
 author="Cas Brugman"
-version="2.0"
+version="3.0"
 script="plugin.gd"

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -27,9 +27,9 @@ func _ready() -> void:
 			if player is AudioStreamPlayer || player is AudioStreamPlayer2D || player is AudioStreamPlayer3D:
 				_voice = player
 			else:
-				push_error("voip_isntance.gd: node:'%s' is not any kind of AudioStreamPlayer!" % custom_voice_audio_stream_player)
+				push_error("node:'%s' is not any kind of AudioStreamPlayer!" % custom_voice_audio_stream_player)
 		else:
-			push_error("voip_isntance.gd: node:'%s' does not exist!" % custom_voice_audio_stream_player)
+			push_error("node:'%s' does not exist!" % custom_voice_audio_stream_player)
 	else:
 		_voice = AudioStreamPlayer.new()
 		add_child(_voice)

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -9,7 +9,7 @@ export var custom_voice_audio_stream_player: NodePath
 
 export var recording: bool = false
 export var listen: bool = false
-export(float, 0.0, 1.0) var input_sensitivity: = 0.01
+export(float, 0.0, 1.0) var input_threshold: = 0.01
 
 var _microphone: VoipMicrophone
 var _voice
@@ -63,13 +63,13 @@ func _process_output():
 			var data = PoolRealArray()
 			data.resize(stereo_data.size())
 
-			if input_sensitivity > 0.0:
+			if input_threshold > 0.0:
 				var max_value = 0.0
 				for i in range(stereo_data.size()):
 					var value = (stereo_data[i].x + stereo_data[i].y) / 2.0
 					max_value = max(value, max_value)
 					data[i] = value
-				if max_value < input_sensitivity:
+				if max_value < input_threshold:
 					return
 			else:
 				for i in range(stereo_data.size()):

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -3,7 +3,6 @@ class_name VoipInstance
 
 signal received_voice_data
 signal send_voice_data
-signal _updated_sample_format
 
 export var custom_voice_audio_stream_player: NodePath
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -9,7 +9,10 @@ export var custom_voice_audio_stream_player: NodePath
 
 export var recording: bool = false
 
-var voip_format: int = AudioStreamSample.FORMAT_8_BITS
+enum FORMAT {_8_BIT = AudioStreamSample.FORMAT_8_BITS, _16_BIT_ = AudioStreamSample.FORMAT_16_BITS}
+
+export(FORMAT) var voip_format: int = AudioStreamSample.FORMAT_16_BITS
+
 var _voip_mix_rate: int = AudioServer.get_mix_rate()
 var _voip_stereo: bool = false
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -18,9 +18,20 @@ var _playback: AudioStreamGeneratorPlayback
 var _receive_buffer := PoolRealArray()
 
 func _ready() -> void:
+	create_mic()
+	create_voice()
+
+func _process(delta: float) -> void:
+	_process_input()
+	_process_output()
+
+func create_mic():
 	_mic = VoipMic.new()
 	add_child(_mic)
+	var record_bus_idx = AudioServer.get_bus_index(_mic.bus)
+	_effect_capture = AudioServer.get_bus_effect(record_bus_idx, 0)
 
+func create_voice():
 	if !custom_voice_audio_stream_player.is_empty():
 		var player = get_node(custom_voice_audio_stream_player)
 		if player != null:
@@ -33,10 +44,6 @@ func _ready() -> void:
 	else:
 		_voice = AudioStreamPlayer.new()
 		add_child(_voice)
-
-	var record_bus_idx = AudioServer.get_bus_index(_mic.bus)
-
-	_effect_capture = AudioServer.get_bus_effect(record_bus_idx, 0)
 
 	var generator := AudioStreamGenerator.new()
 	generator.buffer_length = 0.1
@@ -82,10 +89,6 @@ func _process_output():
 
 			rpc_unreliable("_speak", data,  get_tree().get_network_unique_id())
 			emit_signal("send_voice_data", data)
-
-func _process(delta: float) -> void:
-	_process_input()
-	_process_output()
 
 
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -17,8 +17,8 @@ var _playback: AudioStreamGeneratorPlayback
 var _receive_buffer := PoolRealArray()
 
 func _process(delta: float) -> void:
-	_process_input()
-	_process_output()
+	_process_voice()
+	_process_mic()
 
 func create_mic():
 	_mic = VoipMic.new()
@@ -54,7 +54,7 @@ remote func _speak(sample_data: PoolRealArray, id: int = -1):
 	emit_signal("received_voice_data", sample_data, id)
 	_receive_buffer.append_array(sample_data)
 
-func _process_input():
+func _process_voice():
 	if _playback == null:
 		return
 
@@ -65,7 +65,7 @@ func _process_input():
 		else:
 			_playback.push_frame(Vector2.ZERO)
 
-func _process_output():
+func _process_mic():
 	if recording:
 		if _effect_capture == null:
 			create_mic()

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -8,7 +8,7 @@ export var custom_voice_audio_stream_player: NodePath
 
 export var recording: bool = false
 export var listen: bool = false
-export(float, 0.0, 1.0) var input_threshold: = 0.01
+export(float, 0.0, 1.0) var input_threshold: = 0.005
 
 var _mic: VoipMic
 var _voice

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -10,9 +10,9 @@ export var custom_voice_audio_stream_player: NodePath
 
 var recording: bool = false
 
-var voip_format: int = -1
-var voip_mix_rate: int = -1
-var voip_stereo: bool = true
+var voip_format: int = 0
+var voip_mix_rate: int = 44100
+var voip_stereo: bool = false
 
 var _microphone: VoipMicrophone
 var _voice
@@ -40,25 +40,12 @@ func _ready() -> void:
 	var record_bus_idx = AudioServer.get_bus_index(_microphone.bus)
 	_effect_record = AudioServer.get_bus_effect(record_bus_idx, 0)
 
-remote func _receive_stream_format(_format: int, _mix_rate: int, _stereo: bool):
-	voip_format = _format
-	voip_mix_rate = _mix_rate
-	voip_stereo = _stereo
-
-	emit_signal("_updated_sample_format")
-
-remote func _send_stream_format():
-	rpc("_receive_stream_format", _latest_sample.format, _latest_sample.mix_rate, _latest_sample.stereo)
 
 remote func _speak(sample_data: PoolByteArray, id: int = -1):
 	emit_signal("received_voice_data", sample_data, id)
 
 	var sample = AudioStreamSample.new()
 	sample.data = sample_data
-
-	if voip_format == -1:
-		rpc("_send_stream_format")
-		yield(self, "_updated_sample_format")
 
 	sample.set_format(voip_format)
 	sample.set_mix_rate(voip_mix_rate)

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -67,7 +67,18 @@ func _process(delta: float) -> void:
 					data[i] = frame
 
 			elif voip_format == AudioStreamSample.FORMAT_16_BITS:
-				pass
+				data.resize(stereo_data.size() * 2)
+
+				for i in range (stereo_data.size()):
+					var frame = stereo_data[i]
+					frame = (frame.x + frame.y) / 2.0
+					frame = int(clamp(frame * 32768, -32768, 32767))
+
+					i *= 2
+					for x in range(2):
+						data[i] = frame & 0xFF
+						i += 1
+						frame >>= 8
 
 			rpc_unreliable("_speak", data,  get_tree().get_network_unique_id())
 			emit_signal("send_voice_data", data)

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -10,8 +10,8 @@ export var custom_voice_audio_stream_player: NodePath
 export var recording: bool = false
 
 var voip_format: int = AudioStreamSample.FORMAT_8_BITS
-var voip_mix_rate: int = 44100
-var voip_stereo: bool = false
+var _voip_mix_rate: int = AudioServer.get_mix_rate()
+var _voip_stereo: bool = false
 
 var _microphone: VoipMicrophone
 var _voice
@@ -45,8 +45,8 @@ remote func _speak(sample_data: PoolByteArray, id: int = -1):
 	sample.data = sample_data
 
 	sample.set_format(voip_format)
-	sample.set_mix_rate(voip_mix_rate)
-	sample.set_stereo(voip_stereo)
+	sample.set_mix_rate(_voip_mix_rate)
+	sample.set_stereo(_voip_stereo)
 
 	_voice.stream = sample
 	_voice.play()

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -7,7 +7,7 @@ signal _updated_sample_format
 
 export var custom_voice_audio_stream_player: NodePath
 
-var recording: bool = false
+export var recording: bool = false
 
 var voip_format: int = 0
 var voip_mix_rate: int = 44100

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -5,7 +5,6 @@ signal received_voice_data
 signal send_voice_data
 signal _updated_sample_format
 
-export var min_packet_lenght_seconds: float = 1.0
 export var custom_voice_audio_stream_player: NodePath
 
 var recording: bool = false
@@ -16,9 +15,6 @@ var voip_stereo: bool = false
 
 var _microphone: VoipMicrophone
 var _voice
-var _effect_record: AudioEffectRecord
-var _latest_sample: AudioStreamSample
-var _time_recording: float = 0
 var _effect_capture: AudioEffectCapture
 
 func _ready() -> void:
@@ -39,7 +35,6 @@ func _ready() -> void:
 		add_child(_voice)
 
 	var record_bus_idx = AudioServer.get_bus_index(_microphone.bus)
-	_effect_record = AudioServer.get_bus_effect(record_bus_idx, 0)
 
 	_effect_capture = AudioServer.get_bus_effect(record_bus_idx, 0)
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -55,7 +55,7 @@ func _process_input():
 		else:
 			_playback.push_frame(Vector2.ZERO)
 
-func _process(delta: float) -> void:
+func _process_output():
 	if recording:
 		var stereo_data = _effect_capture.get_buffer(_effect_capture.get_frames_available())
 		if stereo_data.size() > 0:
@@ -71,7 +71,10 @@ func _process(delta: float) -> void:
 
 			rpc_unreliable("_speak", data,  get_tree().get_network_unique_id())
 			emit_signal("send_voice_data", data)
+
+func _process(delta: float) -> void:
 	_process_input()
+	_process_output()
 
 
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -60,10 +60,11 @@ func _process(delta: float) -> void:
 			if voip_format == AudioStreamSample.FORMAT_8_BITS:
 				data.resize(stereo_data.size())
 
-				for frame in stereo_data:
+				for i in range(stereo_data.size()):
+					var frame = stereo_data[i]
 					frame = (frame.x + frame.y) / 2.0
 					frame = int(clamp(frame * 128, -128, 127))
-					data.append(frame)
+					data[i] = frame
 
 			elif voip_format == AudioStreamSample.FORMAT_16_BITS:
 				pass

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -38,8 +38,10 @@ func _ready() -> void:
 
 	_effect_capture = AudioServer.get_bus_effect(record_bus_idx, 0)
 
+	var generator := AudioStreamGenerator.new()
+	generator.buffer_length = 0.1
+	_voice.stream = generator
 
-	_voice.stream = AudioStreamGenerator.new()
 	_playback = _voice.get_stream_playback()
 	_voice.play()
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -8,6 +8,7 @@ signal _updated_sample_format
 export var custom_voice_audio_stream_player: NodePath
 
 export var recording: bool = false
+export var listen: bool = false
 
 enum FORMAT {_8_BIT = AudioStreamSample.FORMAT_8_BITS, _16_BIT_ = AudioStreamSample.FORMAT_16_BITS}
 
@@ -82,6 +83,9 @@ func _process(delta: float) -> void:
 						data[i] = frame & 0xFF
 						i += 1
 						frame >>= 8
+
+			if listen:
+				_speak(data, get_tree().get_network_unique_id())
 
 			rpc_unreliable("_speak", data,  get_tree().get_network_unique_id())
 			emit_signal("send_voice_data", data)

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -9,7 +9,7 @@ export var custom_voice_audio_stream_player: NodePath
 
 export var recording: bool = false
 
-var voip_format: int = 0
+var voip_format: int = AudioStreamSample.FORMAT_8_BITS
 var voip_mix_rate: int = 44100
 var voip_stereo: bool = false
 
@@ -56,9 +56,14 @@ func _process(delta: float) -> void:
 		var stereo_data = _effect_capture.get_buffer(_effect_capture.get_frames_available())
 		if stereo_data.size() > 0:
 			var data = PoolByteArray()
-			for frame in stereo_data:
-				var v = clamp(frame.x * 128, -128, 127)
-				data.append(v)
+
+			if voip_format == AudioStreamSample.FORMAT_8_BITS:
+				for frame in stereo_data:
+					frame = (frame.x + frame.y) / 2.0
+					frame = clamp(frame * 128, -128, 127)
+					data.append(frame)
+			elif voip_format == AudioStreamSample.FORMAT_16_BITS:
+				pass
 
 			rpc_unreliable("_speak", data,  get_tree().get_network_unique_id())
 			emit_signal("send_voice_data", data)

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -17,10 +17,6 @@ var _effect_capture: AudioEffectCapture
 var _playback: AudioStreamGeneratorPlayback
 var _receive_buffer := PoolRealArray()
 
-func _ready() -> void:
-	create_mic()
-	create_voice()
-
 func _process(delta: float) -> void:
 	_process_input()
 	_process_output()
@@ -53,10 +49,16 @@ func create_voice():
 	_voice.play()
 
 remote func _speak(sample_data: PoolRealArray, id: int = -1):
+	if _playback == null:
+		create_voice()
+
 	emit_signal("received_voice_data", sample_data, id)
 	_receive_buffer.append_array(sample_data)
 
 func _process_input():
+	if _playback == null:
+		return
+
 	for i in range(_playback.get_frames_available()):
 		if _receive_buffer.size() > 0:
 			_playback.push_frame(Vector2(_receive_buffer[0], _receive_buffer[0]))
@@ -66,6 +68,9 @@ func _process_input():
 
 func _process_output():
 	if recording:
+		if _effect_capture == null:
+			create_mic()
+
 		var stereo_data = _effect_capture.get_buffer(_effect_capture.get_frames_available())
 		if stereo_data.size() > 0:
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -11,15 +11,15 @@ export var recording: bool = false
 export var listen: bool = false
 export(float, 0.0, 1.0) var input_threshold: = 0.01
 
-var _microphone: VoipMicrophone
+var _mic: VoipMic
 var _voice
 var _effect_capture: AudioEffectCapture
 var _playback: AudioStreamGeneratorPlayback
 var _receive_buffer := PoolRealArray()
 
 func _ready() -> void:
-	_microphone = VoipMicrophone.new()
-	add_child(_microphone)
+	_mic = VoipMic.new()
+	add_child(_mic)
 
 	if !custom_voice_audio_stream_player.is_empty():
 		var player = get_node(custom_voice_audio_stream_player)
@@ -34,7 +34,7 @@ func _ready() -> void:
 		_voice = AudioStreamPlayer.new()
 		add_child(_voice)
 
-	var record_bus_idx = AudioServer.get_bus_index(_microphone.bus)
+	var record_bus_idx = AudioServer.get_bus_index(_mic.bus)
 
 	_effect_capture = AudioServer.get_bus_effect(record_bus_idx, 0)
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -9,12 +9,12 @@ export var custom_voice_audio_stream_player: NodePath
 
 export var recording: bool = false
 export var listen: bool = false
+export(float, 0.0, 1.0) var input_sensitivity: = 0.01
 
 var _microphone: VoipMicrophone
 var _voice
 var _effect_capture: AudioEffectCapture
 var _playback: AudioStreamGeneratorPlayback
-
 var _receive_buffer := PoolRealArray()
 
 func _ready() -> void:
@@ -63,8 +63,17 @@ func _process_output():
 			var data = PoolRealArray()
 			data.resize(stereo_data.size())
 
-			for i in range(stereo_data.size()):
-				data[i] = (stereo_data[i].x + stereo_data[i].y) / 2.0
+			if input_sensitivity > 0.0:
+				var max_value = 0.0
+				for i in range(stereo_data.size()):
+					var value = (stereo_data[i].x + stereo_data[i].y) / 2.0
+					max_value = max(value, max_value)
+					data[i] = value
+				if max_value < input_sensitivity:
+					return
+			else:
+				for i in range(stereo_data.size()):
+					data[i] = (stereo_data[i].x + stereo_data[i].y) / 2.0
 
 			if listen:
 				_speak(data, get_tree().get_network_unique_id())

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -58,10 +58,13 @@ func _process(delta: float) -> void:
 			var data = PoolByteArray()
 
 			if voip_format == AudioStreamSample.FORMAT_8_BITS:
+				data.resize(stereo_data.size())
+
 				for frame in stereo_data:
 					frame = (frame.x + frame.y) / 2.0
-					frame = clamp(frame * 128, -128, 127)
+					frame = int(clamp(frame * 128, -128, 127))
 					data.append(frame)
+
 			elif voip_format == AudioStreamSample.FORMAT_16_BITS:
 				pass
 

--- a/addons/godot-voip/scripts/voip_instance.gd
+++ b/addons/godot-voip/scripts/voip_instance.gd
@@ -47,7 +47,7 @@ remote func _speak(sample_data: PoolRealArray, id: int = -1):
 	emit_signal("received_voice_data", sample_data, id)
 	_receive_buffer.append_array(sample_data)
 
-func _fill_buffer():
+func _process_input():
 	for i in range(_playback.get_frames_available()):
 		if _receive_buffer.size() > 0:
 			_playback.push_frame(Vector2(_receive_buffer[0], _receive_buffer[0]))
@@ -71,7 +71,7 @@ func _process(delta: float) -> void:
 
 			rpc_unreliable("_speak", data,  get_tree().get_network_unique_id())
 			emit_signal("send_voice_data", data)
-	_fill_buffer()
+	_process_input()
 
 
 

--- a/addons/godot-voip/scripts/voip_mic.gd
+++ b/addons/godot-voip/scripts/voip_mic.gd
@@ -1,12 +1,12 @@
 extends AudioStreamPlayer
-class_name VoipMicrophone
+class_name VoipMic
 
 func _ready() -> void:
 	var current_number = 0
-	while AudioServer.get_bus_index("VoipMicrophoneRecorder" + str(current_number)) != -1:
+	while AudioServer.get_bus_index("VoipMicRecorder" + str(current_number)) != -1:
 		current_number += 1
 
-	var bus_name = "VoipMicrophoneRecorder" + str(current_number)
+	var bus_name = "VoipMicRecorder" + str(current_number)
 	var idx = AudioServer.bus_count
 
 	AudioServer.add_bus(idx)

--- a/addons/godot-voip/scripts/voip_microphone.gd
+++ b/addons/godot-voip/scripts/voip_microphone.gd
@@ -12,7 +12,6 @@ func _ready() -> void:
 	AudioServer.add_bus(idx)
 	AudioServer.set_bus_name(idx, bus_name)
 
-	AudioServer.add_bus_effect(idx, AudioEffectRecord.new())
 	AudioServer.add_bus_effect(idx, AudioEffectCapture.new())
 
 	AudioServer.set_bus_mute(idx, true)

--- a/addons/godot-voip/scripts/voip_microphone.gd
+++ b/addons/godot-voip/scripts/voip_microphone.gd
@@ -13,6 +13,8 @@ func _ready() -> void:
 	AudioServer.set_bus_name(idx, bus_name)
 
 	AudioServer.add_bus_effect(idx, AudioEffectRecord.new())
+	AudioServer.add_bus_effect(idx, AudioEffectCapture.new())
+
 	AudioServer.set_bus_mute(idx, true)
 
 	bus = bus_name

--- a/project.godot
+++ b/project.godot
@@ -49,4 +49,5 @@ enabled=PoolStringArray( "godot-voip" )
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
 environment/default_environment="res://default_env.tres"

--- a/project.godot
+++ b/project.godot
@@ -10,6 +10,11 @@ config_version=4
 
 _global_script_classes=[ {
 "base": "Node",
+"class": "Network",
+"language": "GDScript",
+"path": "res://addons/godot-voip/demo/Network.gd"
+}, {
+"base": "Node",
 "class": "VoipInstance",
 "language": "GDScript",
 "path": "res://addons/godot-voip/scripts/voip_instance.gd"
@@ -20,6 +25,7 @@ _global_script_classes=[ {
 "path": "res://addons/godot-voip/scripts/voip_microphone.gd"
 } ]
 _global_script_class_icons={
+"Network": "",
 "VoipInstance": "",
 "VoipMicrophone": ""
 }

--- a/project.godot
+++ b/project.godot
@@ -20,14 +20,14 @@ _global_script_classes=[ {
 "path": "res://addons/godot-voip/scripts/voip_instance.gd"
 }, {
 "base": "AudioStreamPlayer",
-"class": "VoipMicrophone",
+"class": "VoipMic",
 "language": "GDScript",
-"path": "res://addons/godot-voip/scripts/voip_microphone.gd"
+"path": "res://addons/godot-voip/scripts/voip_mic.gd"
 } ]
 _global_script_class_icons={
 "Network": "",
 "VoipInstance": "",
-"VoipMicrophone": ""
+"VoipMic": ""
 }
 
 [application]


### PR DESCRIPTION
Updated to use the new merged AudioEffectCapture godotengine/godot#45593. (fixes #6)

Other changes and improvements include:
- Voice is now transmitted every frame, improving delays and interruptions.
- Incoming voice frames are played directly using an AudioStreamGenerator instead of using individual AudioStreamSamples, eliminating pops but introducing a delay.
- Transmitted voice is mono instead of stereo, improving bandwidth. (fixes  #5)
- Fixed memory leak associated with AudioEffectRecord.
- Audio is transmitted using PoolRealArrays (32 bit).
- Compatible with other mix rates.
- Demo UI refactoring and improvements.
- Added listen mode for testing and exported a few more variables.
- Added input threshold parameter.
- Added client/server IP and port inputs for demo

Any feedback is greatly appreciated!
